### PR TITLE
Fixed Auth on GitHub App Usage

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -149,8 +149,9 @@ func backupRepository(event github.WebhookPayload, logger *zap.Logger) error {
 
 	_, err := git.PlainClone(backupDir, false, &git.CloneOptions{
 		URL: event.Repository.CloneURL,
-		Auth: &githttp.TokenAuth{
-			Token: token,
+		Auth: &githttp.BasicAuth{
+			Username: "x-access-token",
+			Password: token,
 		},
 		Progress: os.Stdout,
 	})


### PR DESCRIPTION
This pull request includes a change to the `cmd/webhook/main.go` file to update the authentication method used in the `backupRepository` function. The most important change is switching from `TokenAuth` to `BasicAuth` for cloning a repository.

Authentication update:

* [`cmd/webhook/main.go`](diffhunk://#diff-d66a55a199ff817b0b9bfbe228afc8185087487daf79edd85e2a1a7d26a5a49eL152-R154): Changed the authentication method from `githttp.TokenAuth` to `githttp.BasicAuth` in the `backupRepository` function to use a username and token for repository cloning.