### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -131,6 +131,14 @@ func isMainBranch(ref string) bool {
 }
 
 func backupRepository(event github.WebhookPayload, logger *zap.Logger) error {
+	// Validate repository owner and name
+	if strings.Contains(event.Repository.Owner.Name, "/") || strings.Contains(event.Repository.Owner.Name, "\\") || strings.Contains(event.Repository.Owner.Name, "..") {
+		return fmt.Errorf("invalid repository owner name: %s", event.Repository.Owner.Name)
+	}
+	if strings.Contains(event.Repository.Name, "/") || strings.Contains(event.Repository.Name, "\\") || strings.Contains(event.Repository.Name, "..") {
+		return fmt.Errorf("invalid repository name: %s", event.Repository.Name)
+	}
+
 	// Create backup directory with timestamp
 	timestamp := time.Now().Format("20060102_150405")
 	backupDir := filepath.Join("backups", event.Repository.Owner.Name,


### PR DESCRIPTION
Fixes [https://github.com/samilton/GitSaver/security/code-scanning/1](https://github.com/samilton/GitSaver/security/code-scanning/1)

To fix the problem, we need to validate and sanitize the user-controlled data before using it to construct the file path. Specifically, we should ensure that `event.Repository.Owner.Name` and `event.Repository.Name` do not contain any path traversal sequences or invalid characters. We can achieve this by checking for the presence of path separators ("/" or "\\") and ".." sequences, and rejecting the input if any are found.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
